### PR TITLE
Fix crash in validating MultiCurrencyAmounts

### DIFF
--- a/SwiftBeanCountModel/Transaction.swift
+++ b/SwiftBeanCountModel/Transaction.swift
@@ -64,7 +64,7 @@ public class Transaction {
             }
         }
         for (commodity, decimal) in amount.amounts {
-            let decimalDigits = amount.decimalDigits[commodity]!
+            let decimalDigits = amount.decimalDigits[commodity] ?? 0
             var tolerance = Decimal()
             if decimalDigits != 0 {
                 tolerance = Decimal(sign: FloatingPointSign.plus, exponent: -(decimalDigits + 1), significand: Decimal(5))

--- a/SwiftBeanCountModelTests/TransactionTests.swift
+++ b/SwiftBeanCountModelTests/TransactionTests.swift
@@ -156,6 +156,21 @@ class TransactionTests: XCTestCase {
         XCTAssertFalse(transaction.isValid())
     }
 
+    func testIsValidUnusedCommodity() {
+        //Assets:Checking 10.00000 CAD @ 0.85251 EUR
+
+        account1!.opening = date
+        let transactionMetaData = TransactionMetaData(date: date!, payee: "Payee", narration: "Narration", flag: Flag.complete, tags: [])
+        let transaction = Transaction(metaData: transactionMetaData)
+        let amount1 = Amount(number: Decimal(10.000_00), commodity: Commodity(symbol: "CAD"), decimalDigits: 5)
+        // 0.85251
+        let price = Amount(number: Decimal(sign: FloatingPointSign.plus, exponent: -5, significand: Decimal(85_251)), commodity: Commodity(symbol: "EUR"), decimalDigits: 5)
+        let posting1 = Posting(account: account1!, amount: amount1, transaction: transaction, price: price)
+        transaction.postings.append(posting1)
+
+        XCTAssertFalse(transaction.isValid())
+    }
+
     func testIsValidBalancedTolerance() {
         //Assets:Cash     -8.52  EUR
         //Assets:Checking 10.00000 CAD @ 0.85250 EUR


### PR DESCRIPTION
There was a force unwrap which crashed in certain conditions.
Basically it assumed that all currencies in a transaction were
used as amount as well - this is true for balanced transactions,
but e.g. if the transaction has only one posting with a price
in another currency the method would crash

Add test to catch this in the future