### PR TITLE
Revert "Change transactions, plugins, events and customs to Set"

### DIFF
--- a/SwiftBeanCountModel.xcodeproj/project.pbxproj
+++ b/SwiftBeanCountModel.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F90E0C3E24737BCA00F4C3B6 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90E0C3D24737BCA00F4C3B6 /* Option.swift */; };
+		F90E0C4024737D9400F4C3B6 /* OptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90E0C3F24737D9400F4C3B6 /* OptionTests.swift */; };
 		F9159477233CA18400ECFFA7 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9159476233CA18400ECFFA7 /* Event.swift */; };
 		F915947A233CA21F00ECFFA7 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9159479233CA21F00ECFFA7 /* EventTests.swift */; };
 		F940339920B251CC00DAC55F /* ValidationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F940339820B251CC00DAC55F /* ValidationResult.swift */; };
@@ -55,6 +57,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		F90E0C3D24737BCA00F4C3B6 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
+		F90E0C3F24737D9400F4C3B6 /* OptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionTests.swift; sourceTree = "<group>"; };
 		F9159476233CA18400ECFFA7 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 		F9159479233CA21F00ECFFA7 /* EventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
 		F940339820B251CC00DAC55F /* ValidationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationResult.swift; sourceTree = "<group>"; };
@@ -152,6 +156,7 @@
 				F9B9E159232DB45B00811B3F /* Inventory.swift */,
 				F9C1F371233C7E5400357FF0 /* Custom.swift */,
 				F9159476233CA18400ECFFA7 /* Event.swift */,
+				F90E0C3D24737BCA00F4C3B6 /* Option.swift */,
 				F9C1F375233C916700357FF0 /* MetaDataAttachable.swift */,
 				F991CD131F5534C000EE31E5 /* Info.plist */,
 			);
@@ -177,6 +182,7 @@
 				F9B9E15B232DBCB000811B3F /* InventoryTests.swift */,
 				F9C1F373233C8C6D00357FF0 /* CustomTests.swift */,
 				F9159479233CA21F00ECFFA7 /* EventTests.swift */,
+				F90E0C3F24737D9400F4C3B6 /* OptionTests.swift */,
 				F991CD1F1F5534C000EE31E5 /* Info.plist */,
 			);
 			path = SwiftBeanCountModelTests;
@@ -317,6 +323,7 @@
 				F9B7A88C1F553ABE0062B1CB /* MultiCurrencyAmount.swift in Sources */,
 				F9B7A8871F553ABE0062B1CB /* Account.swift in Sources */,
 				F9B7A88D1F553ABE0062B1CB /* Posting.swift in Sources */,
+				F90E0C3E24737BCA00F4C3B6 /* Option.swift in Sources */,
 				F9B7A8881F553ABE0062B1CB /* Amount.swift in Sources */,
 				F9B9E1522326213B00811B3F /* Cost.swift in Sources */,
 				F9B7A88B1F553ABE0062B1CB /* Ledger.swift in Sources */,
@@ -336,6 +343,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F90E0C4024737D9400F4C3B6 /* OptionTests.swift in Sources */,
 				F915947A233CA21F00ECFFA7 /* EventTests.swift in Sources */,
 				F99E58A720A90F3100A05AFE /* PriceTests.swift in Sources */,
 				F9B7A8841F553AB90062B1CB /* TagTests.swift in Sources */,

--- a/SwiftBeanCountModel/Custom.swift
+++ b/SwiftBeanCountModel/Custom.swift
@@ -70,5 +70,10 @@ extension Custom: Equatable {
 
 }
 
-extension Custom: Hashable {
+extension Custom: Comparable {
+
+    public static func < (lhs: Custom, rhs: Custom) -> Bool {
+       String(describing: lhs) < String(describing: rhs)
+    }
+
 }

--- a/SwiftBeanCountModel/Event.swift
+++ b/SwiftBeanCountModel/Event.swift
@@ -70,5 +70,10 @@ extension Event: Equatable {
 
 }
 
-extension Event: Hashable {
+extension Event: Comparable {
+
+    public static func < (lhs: Event, rhs: Event) -> Bool {
+        String(describing: lhs) < String(describing: rhs)
+    }
+
 }

--- a/SwiftBeanCountModel/Ledger.swift
+++ b/SwiftBeanCountModel/Ledger.swift
@@ -18,7 +18,7 @@ public enum LedgerError: Error {
 public class Ledger {
 
     /// Array of all `Transaction`s in this ledger
-    public private(set) var transactions = Set<Transaction>()
+    public private(set) var transactions = [Transaction]()
 
     /// Errors which this ledger contains
     public var errors = [String]()
@@ -41,16 +41,16 @@ public class Ledger {
     public var accountGroups: [AccountGroup] { Array(accountGroup.values) }
 
     /// Array of all plugins
-    public var plugins = Set<String>()
+    public var plugins = [String]()
 
     /// Array of all options
-    public var option = [String: [String]]()
+    public var option = [Option]()
 
     /// Array of all events
-    public var events = Set<Event>()
+    public var events = [Event]()
 
     /// Array of all Custom directives
-    public var custom = Set<Custom>()
+    public var custom = [Custom]()
 
     private var commodity = [String: Commodity]()
     private var account = [String: Account]()
@@ -84,7 +84,7 @@ public class Ledger {
     public func add(_ transaction: Transaction) -> Transaction {
         let newTransaction = Transaction(metaData: getTransactionMetaData(for: transaction.metaData))
         newTransaction.postings = transaction.postings.map { try! getPosting(for: $0, transaction: newTransaction) } // swiftlint:disable:this force_try
-        transactions.insert(newTransaction)
+        transactions.append(newTransaction)
         return newTransaction
     }
 
@@ -314,7 +314,7 @@ extension Ledger: CustomStringConvertible {
     /// It consists of all `Account` and `Transaction` statements, but does not include `errors`
     public var description: String {
         var string = ""
-        string.append(self.option.map { key, values in "option \"\(key)\" \(values.map { "\"\($0)\"" }.joined(separator: " "))" }.joined(separator: "\n"))
+        string.append(self.option.map { String(describing: $0) }.joined(separator: "\n"))
         if !string.isEmpty && !self.plugins.isEmpty {
             string.append("\n")
         }
@@ -358,12 +358,12 @@ extension Ledger: Equatable {
         lhs.account == rhs.account
             && rhs.commodity == lhs.commodity
             && rhs.tag == lhs.tag
-            && rhs.transactions == lhs.transactions
+            && rhs.transactions.sorted() == lhs.transactions.sorted()
             && rhs.price == lhs.price
-            && rhs.custom == lhs.custom
-            && rhs.option == lhs.option
-            && rhs.events == lhs.events
-            && rhs.plugins == lhs.plugins
+            && rhs.custom.sorted() == lhs.custom.sorted()
+            && rhs.option.sorted() == lhs.option.sorted()
+            && rhs.events.sorted() == lhs.events.sorted()
+            && rhs.plugins.sorted() == lhs.plugins.sorted()
     }
 
 }

--- a/SwiftBeanCountModel/Option.swift
+++ b/SwiftBeanCountModel/Option.swift
@@ -1,0 +1,35 @@
+//
+//  Option.swift
+//  SwiftBeanCountModel
+//
+//  Created by Steffen Kötte on 2020-05-18.
+//  Copyright © 2020 Steffen Kötte. All rights reserved.
+//
+
+import Foundation
+
+/// Option to control bahaviour of Beancount
+public struct Option {
+
+    /// name of the option
+    public let name: String
+    /// value the option should be set to
+    public let value: String
+
+}
+
+extension Option: CustomStringConvertible {
+
+    public var description: String {
+        "option \"\(name)\" \"\(value)\""
+    }
+
+}
+
+extension Option: Comparable {
+
+    public static func < (lhs: Option, rhs: Option) -> Bool {
+        String(describing: lhs) < String(describing: rhs)
+    }
+
+}

--- a/SwiftBeanCountModel/Transaction.swift
+++ b/SwiftBeanCountModel/Transaction.swift
@@ -117,3 +117,11 @@ extension Transaction: Hashable {
     }
 
 }
+
+extension Transaction: Comparable {
+
+    public static func < (lhs: Transaction, rhs: Transaction) -> Bool {
+        String(describing: lhs) < String(describing: rhs)
+    }
+
+}

--- a/SwiftBeanCountModelTests/CustomTests.swift
+++ b/SwiftBeanCountModelTests/CustomTests.swift
@@ -24,24 +24,32 @@ class CustomTests: XCTestCase {
         XCTAssertNotEqual(custom1, custom2)
         custom2.metaData["A"] = "B"
         XCTAssertEqual(custom1, custom2)
+        XCTAssertFalse(custom1 < custom2)
+        XCTAssertFalse(custom2 < custom1)
     }
 
     func testEqualRespectsDate() {
         let custom1 = Custom(date: date1, name: "A", values: ["B"])
         let custom2 = Custom(date: date2, name: "A", values: ["B"])
         XCTAssertNotEqual(custom1, custom2)
+        XCTAssert(custom1 < custom2)
+        XCTAssertFalse(custom2 < custom1)
     }
 
     func testEqualRespectsName() {
         let custom1 = Custom(date: date1, name: "A", values: ["B"])
         let custom2 = Custom(date: date1, name: "C", values: ["B"])
         XCTAssertNotEqual(custom1, custom2)
+        XCTAssert(custom1 < custom2)
+        XCTAssertFalse(custom2 < custom1)
     }
 
     func testEqualRespectsValue() {
         let custom1 = Custom(date: date1, name: "A", values: ["B"])
         let custom2 = Custom(date: date1, name: "A", values: ["B", "C"])
         XCTAssertNotEqual(custom1, custom2)
+        XCTAssert(custom1 < custom2)
+        XCTAssertFalse(custom2 < custom1)
     }
 
     func testDescription() {

--- a/SwiftBeanCountModelTests/EventTests.swift
+++ b/SwiftBeanCountModelTests/EventTests.swift
@@ -15,33 +15,48 @@ class EventTests: XCTestCase {
     let date2 = Date(timeIntervalSince1970: 1_496_991_600)
 
     func testEqual() {
-        var event1 = Event(date: date1, name: "A", value: "B")
-        var event2 = Event(date: date1, name: "A", value: "B")
+        let event1 = Event(date: date1, name: "A", value: "B")
+        let event2 = Event(date: date1, name: "A", value: "B")
         XCTAssertEqual(event1, event2)
-
-        // meta data
-        event1.metaData["A"] = "B"
-        XCTAssertNotEqual(event1, event2)
-        event2.metaData["A"] = "B"
-        XCTAssertEqual(event1, event2)
+        XCTAssertFalse(event1 < event2)
+        XCTAssertFalse(event2 < event1)
     }
 
     func testEqualRespectsDate() {
         let event1 = Event(date: date1, name: "A", value: "B")
         let event2 = Event(date: date2, name: "A", value: "B")
         XCTAssertNotEqual(event1, event2)
+        XCTAssert(event1 < event2)
+        XCTAssertFalse(event2 < event1)
     }
 
     func testEqualRespectsName() {
         let event1 = Event(date: date1, name: "A", value: "B")
         let event2 = Event(date: date1, name: "C", value: "B")
         XCTAssertNotEqual(event1, event2)
+        XCTAssert(event1 < event2)
+        XCTAssertFalse(event2 < event1)
     }
 
     func testEqualRespectsValue() {
         let event1 = Event(date: date1, name: "A", value: "B")
         let event2 = Event(date: date1, name: "A", value: "C")
         XCTAssertNotEqual(event1, event2)
+        XCTAssert(event1 < event2)
+        XCTAssertFalse(event2 < event1)
+    }
+
+    func testEqualRespectsMetaData() {
+        var event1 = Event(date: date1, name: "A", value: "B")
+        var event2 = Event(date: date1, name: "A", value: "B")
+        event1.metaData["A"] = "B"
+        XCTAssertNotEqual(event1, event2)
+        XCTAssertFalse(event1 < event2)
+        XCTAssert(event2 < event1)
+        event2.metaData["A"] = "B"
+        XCTAssertEqual(event1, event2)
+        XCTAssertFalse(event1 < event2)
+        XCTAssertFalse(event2 < event1)
     }
 
     func testDescription() {

--- a/SwiftBeanCountModelTests/LedgerTests.swift
+++ b/SwiftBeanCountModelTests/LedgerTests.swift
@@ -346,65 +346,51 @@ class LedgerTests: XCTestCase {
 
     func testDescriptionOptions() {
         let ledger = Ledger()
-        ledger.option["a"] = ["b", "c"]
-        XCTAssertEqual(String(describing: ledger), "option \"a\" \"b\" \"c\"")
-        ledger.option["z"] = ["y"]
-        let string1 = "option \"a\" \"b\" \"c\"\noption \"z\" \"y\""
-        let string2 = "option \"z\" \"y\"\noption \"a\" \"b\" \"c\""
-        let ledgerString1 = String(describing: ledger)
-        XCTAssert(ledgerString1 == string1 || ledgerString1 == string2)
-        ledger.plugins.insert("p") // Test new line after options
-        let ledgerString2 = String(describing: ledger)
-        XCTAssert(ledgerString2 == "\(string1)\nplugin \"p\"" || ledgerString2 == "\(string2)\nplugin \"p\"")
+        let option1 = Option(name: "a", value: "b")
+        ledger.option.append(option1)
+        XCTAssertEqual(String(describing: ledger), String(describing: option1))
+        let option2 = Option(name: "z", value: "y")
+        ledger.option.append(option2)
+        XCTAssert(String(describing: ledger) == "\(String(describing: option1))\n\(String(describing: option2))")
+        ledger.plugins.append("p") // Test new line after options
+        XCTAssert(String(describing: ledger) == "\(String(describing: option1))\n\(String(describing: option2))\nplugin \"p\"")
     }
 
     func testDescriptionPlugins() {
         let ledger = Ledger()
-        ledger.plugins.insert("p")
+        ledger.plugins.append("p")
         XCTAssertEqual(String(describing: ledger), "plugin \"p\"")
-        ledger.plugins.insert("p1")
-        let string1 = "plugin \"p\"\nplugin \"p1\""
-        let string2 = "plugin \"p1\"\nplugin \"p\""
-        let ledgerString1 = String(describing: ledger)
-        XCTAssert(ledgerString1 == string1 || ledgerString1 == string2)
+        ledger.plugins.append("p1")
+        XCTAssert(String(describing: ledger) == "plugin \"p\"\nplugin \"p1\"")
         let custom = Custom(date: Date(timeIntervalSince1970: 1_497_078_000), name: "a", values: ["b"])
-        ledger.custom.insert(custom) // Test new line after plugins
-        let ledgerString2 = String(describing: ledger)
-        XCTAssert(ledgerString2 == "\(string1)\n\(String(describing: custom))" || ledgerString2 == "\(string2)\n\(String(describing: custom))")
+        ledger.custom.append(custom) // Test new line after plugins
+        XCTAssert(String(describing: ledger) == "plugin \"p\"\nplugin \"p1\"\n\(String(describing: custom))")
     }
 
     func testDescriptionCustoms() {
         let ledger = Ledger()
         let custom1 = Custom(date: Date(timeIntervalSince1970: 1_497_078_000), name: "a", values: ["b"])
         let custom2 = Custom(date: Date(timeIntervalSince1970: 1_496_991_600), name: "c", values: ["d", "e"])
-        ledger.custom.insert(custom1)
+        ledger.custom.append(custom1)
         XCTAssertEqual(String(describing: ledger), String(describing: custom1))
-        ledger.custom.insert(custom2)
-        let ledgerString1 = String(describing: ledger)
-        XCTAssert(ledgerString1 == "\(String(describing: custom1))\n\(String(describing: custom2))"
-            || ledgerString1 == "\(String(describing: custom2))\n\(String(describing: custom1))")
+        ledger.custom.append(custom2)
+        XCTAssert(String(describing: ledger) == "\(String(describing: custom1))\n\(String(describing: custom2))")
         let event = Event(date: Date(timeIntervalSince1970: 1_497_078_000), name: "e", value: "e1")
-        ledger.events.insert(event) // Test new line after customs
-        let ledgerString2 = String(describing: ledger)
-        XCTAssert(ledgerString2 == "\(String(describing: custom1))\n\(String(describing: custom2))\n\(String(describing: event))"
-            || ledgerString2 == "\(String(describing: custom2))\n\(String(describing: custom1))\n\(String(describing: event))")
+        ledger.events.append(event) // Test new line after customs
+        XCTAssert(String(describing: ledger) == "\(String(describing: custom1))\n\(String(describing: custom2))\n\(String(describing: event))")
     }
 
     func testDescriptionEvents() {
         let ledger = Ledger()
         let event1 = Event(date: Date(timeIntervalSince1970: 1_497_078_000), name: "e", value: "e1")
         let event2 = Event(date: Date(timeIntervalSince1970: 1_496_991_600), name: "c", value: "d")
-        ledger.events.insert(event1)
+        ledger.events.append(event1)
         XCTAssertEqual(String(describing: ledger), String(describing: event1))
-        ledger.events.insert(event2)
-        let ledgerString1 = String(describing: ledger)
-        XCTAssert(ledgerString1 == "\(String(describing: event1))\n\(String(describing: event2))"
-            || ledgerString1 == "\(String(describing: event2))\n\(String(describing: event1))")
+        ledger.events.append(event2)
+        XCTAssert(String(describing: ledger) == "\(String(describing: event1))\n\(String(describing: event2))")
         let commodity = Commodity(symbol: "EUR", opening: Date(timeIntervalSince1970: 1_496_991_600))
         try! ledger.add(commodity) // Test new line after events
-        let ledgerString2 = String(describing: ledger)
-        XCTAssert(ledgerString2 == "\(String(describing: event1))\n\(String(describing: event2))\n\(String(describing: commodity))"
-            || ledgerString2 == "\(String(describing: event2))\n\(String(describing: event1))\n\(String(describing: commodity))")
+        XCTAssert(String(describing: ledger) == "\(String(describing: event1))\n\(String(describing: event2))\n\(String(describing: commodity))")
     }
 
     func testEqualEmpty() {
@@ -530,13 +516,13 @@ class LedgerTests: XCTestCase {
         let custom1 = Custom(date: Date(), name: "test", values: ["test1"])
         let custom2 = Custom(date: Date(), name: "test", values: ["test1", "test2"])
 
-        ledger1.custom.insert(custom1)
+        ledger1.custom.append(custom1)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger2.custom.insert(custom2)
+        ledger2.custom.append(custom2)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger1.custom.insert(custom2)
+        ledger1.custom.append(custom2)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger2.custom.insert(custom1)
+        ledger2.custom.append(custom1)
         XCTAssertEqual(ledger1, ledger2)
     }
 
@@ -544,11 +530,15 @@ class LedgerTests: XCTestCase {
         let ledger1 = Ledger()
         let ledger2 = Ledger()
 
-        ledger1.option["a"] = ["b", "c"]
+        let option1 = Option(name: "a", value: "b")
+        let option2 = Option(name: "a", value: "c")
+
+        ledger1.option.append(option1)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger2.option["a"] = ["b", "c", "d"]
+        ledger2.option.append(option2)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger1.option["a"] = ["b", "c", "d"]
+        ledger2.option.append(option1)
+        ledger1.option.append(option2)
         XCTAssertEqual(ledger1, ledger2)
     }
 
@@ -559,13 +549,13 @@ class LedgerTests: XCTestCase {
         let event1 = Event(date: Date(), name: "event", value: "event_value1")
         let event2 = Event(date: Date(), name: "event", value: "event_value2")
 
-        ledger1.events.insert(event1)
+        ledger1.events.append(event1)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger2.events.insert(event2)
+        ledger2.events.append(event2)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger1.events.insert(event2)
+        ledger1.events.append(event2)
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger2.events.insert(event1)
+        ledger2.events.append(event1)
         XCTAssertEqual(ledger1, ledger2)
     }
 
@@ -573,13 +563,13 @@ class LedgerTests: XCTestCase {
         let ledger1 = Ledger()
         let ledger2 = Ledger()
 
-        ledger1.plugins.insert("New Plugin")
+        ledger1.plugins.append("New Plugin")
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger2.plugins.insert("New Plugin1")
+        ledger2.plugins.append("New Plugin1")
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger1.plugins.insert("New Plugin1")
+        ledger1.plugins.append("New Plugin1")
         XCTAssertNotEqual(ledger1, ledger2)
-        ledger2.plugins.insert("New Plugin")
+        ledger2.plugins.append("New Plugin")
         XCTAssertEqual(ledger1, ledger2)
     }
 

--- a/SwiftBeanCountModelTests/OptionTests.swift
+++ b/SwiftBeanCountModelTests/OptionTests.swift
@@ -1,0 +1,32 @@
+//
+//  OptionTests.swift
+//  SwiftBeanCountModelTests
+//
+//  Created by Steffen Kötte on 2020-05-18.
+//  Copyright © 2020 Steffen Kötte. All rights reserved.
+//
+
+@testable import SwiftBeanCountModel
+import XCTest
+
+class OptionTests: XCTestCase {
+
+    func testDescription() {
+        let option = Option(name: "name", value: "value1")
+        XCTAssertEqual(String(describing: option), "option \"name\" \"value1\"")
+
+        let optionSpecialCharacters = Option(name: "😂", value: "😀")
+        XCTAssertEqual(String(describing: optionSpecialCharacters), "option \"😂\" \"😀\"")
+    }
+
+    func testComparable() {
+        let option1 = Option(name: "name", value: "value1")
+        let option2 = Option(name: "name", value: "value1")
+        let option3 = Option(name: "name1", value: "value1") // check name
+        let option4 = Option(name: "name", value: "value2") // check value
+        XCTAssertEqual(option1, option2)
+        XCTAssertNotEqual(option1, option3)
+        XCTAssertNotEqual(option1, option4)
+    }
+
+}

--- a/SwiftBeanCountModelTests/TransactionTests.swift
+++ b/SwiftBeanCountModelTests/TransactionTests.swift
@@ -11,12 +11,12 @@ import XCTest
 
 class TransactionTests: XCTestCase {
 
-    var transaction1WithoutPosting: Transaction?
-    var transaction2WithoutPosting: Transaction?
-    var transaction1WithPosting1: Transaction?
-    var transaction3WithPosting1: Transaction?
-    var transaction1WithPosting1And2: Transaction?
-    var transaction2WithPosting1And2: Transaction?
+    var transaction1WithoutPosting: Transaction!
+    var transaction2WithoutPosting: Transaction!
+    var transaction1WithPosting1: Transaction!
+    var transaction3WithPosting1: Transaction!
+    var transaction1WithPosting1And2: Transaction!
+    var transaction2WithPosting1And2: Transaction!
     var account1: Account?
     var account2: Account?
     var date: Date?
@@ -73,18 +73,26 @@ class TransactionTests: XCTestCase {
 
     func testEqual() {
         XCTAssertEqual(transaction1WithoutPosting, transaction2WithoutPosting)
+        XCTAssertFalse(transaction1WithoutPosting < transaction2WithoutPosting)
+        XCTAssertFalse(transaction2WithoutPosting < transaction1WithoutPosting)
     }
 
     func testEqualWithPostings() {
         XCTAssertEqual(transaction1WithPosting1And2, transaction2WithPosting1And2)
+        XCTAssertFalse(transaction1WithPosting1And2 < transaction2WithPosting1And2)
+        XCTAssertFalse(transaction2WithPosting1And2 < transaction1WithPosting1And2)
     }
 
     func testEqualRespectsPostings() {
         XCTAssertNotEqual(transaction1WithPosting1, transaction1WithPosting1And2)
+        XCTAssert(transaction1WithPosting1 < transaction1WithPosting1And2)
+        XCTAssertFalse(transaction1WithPosting1And2 < transaction1WithPosting1)
     }
 
     func testEqualRespectsTransactionMetaData() {
         XCTAssertNotEqual(transaction1WithPosting1, transaction3WithPosting1)
+        XCTAssertFalse(transaction1WithPosting1 < transaction3WithPosting1)
+        XCTAssert(transaction3WithPosting1 < transaction1WithPosting1)
     }
 
     func testIsValid() {


### PR DESCRIPTION
Transactions can be duplicated, so cannot be a Set. For the rest
it is nice to keep the order to e.g. not mix it up when writing it out.

Make a some things comparable to allow comparing the contents of these
arrays without taking the order into account

Own class for Option

This reverts commit 916cea5dae88ee4aaf7a0c799cd060104d834739.