### PR TITLE
Remove conditional PR trigger for action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,7 @@ name: Continuous Integration
 on:
   pull_request:
     branches:
-      - master
-    paths:
-      - '.github/workflows/ci.yml'
-      - '.swiftlint.yml'
-      - '**/*.swift'
+    - master
   push:
     branches:
     - master


### PR DESCRIPTION
Required status checks don't work together with the restrictions, so we need to run the checks every time