### PR TITLE
Fix running documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,8 @@
 name: Documentation
 
 on:
-  push:
-    tags:
-    - v*
+  release:
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
Apparently with release drafter the tag push event is not send, so need to use the release event