### PR TITLE
Address flaky test

### DIFF
--- a/Tests/SwiftBeanCountModelTests/LedgerTests.swift
+++ b/Tests/SwiftBeanCountModelTests/LedgerTests.swift
@@ -484,7 +484,7 @@ class LedgerTests: XCTestCase {
         let amount1 = Amount(number: 1, commoditySymbol: TestUtils.cad, decimalDigits: 1)
         let amount2 = Amount(number: 1, commoditySymbol: TestUtils.cad, decimalDigits: 2)
         let price1 = try Price(date: Date(), commoditySymbol: TestUtils.eur, amount: amount1)
-        let price2 = try Price(date: Date(), commoditySymbol: TestUtils.eur, amount: amount2)
+        let price2 = try Price(date: Date() + 1, commoditySymbol: TestUtils.eur, amount: amount2)
 
         try ledger1.add(price1)
         XCTAssertNotEqual(ledger1, ledger2)


### PR DESCRIPTION
Dates need to be different for prices to be added. But sometimes the execution was too fast